### PR TITLE
Add Relays page

### DIFF
--- a/docs/Relays.md
+++ b/docs/Relays.md
@@ -1,10 +1,8 @@
 AutoFixture is focused on creating instances of concrete types. For this reason it doesn't have any support for non-concrete types like interfaces and abstract classes.
 
-Most of the time, AutoFixture needs to resort to other libraries, like Moq, to create objects implementing an interface or representing a dummy specialization of an abstract class.
+By default, AutoFixture is only able to work with concrete types. In some cases, interfaces and abstract classes have an implementation or a subtype that can be used as default. To handle cases like this, AutoFixture offers the class `TypeRelay`.
 
-Sometimes, it's sufficient to return a concrete type whenever a non-concrete type is requested. To handle cases like this, AutoFixture offers the class `TypeRelay`.
-
-A `TypeRelay` is a customization that can be fed to the Fixture that simply maps relays requests of a certain type to another one.
+A `TypeRelay` is a customization that can be used to instruct the Fixture to relay requests of a certain type to another one.
 
 ```csharp
 public abstract class Animal { }
@@ -14,14 +12,16 @@ public class Dog : Animal { }
 [Test]
 public void Fixture_should_return_relayed_type()
 {
+    // ARRANGE
     var fixture = new Fixture();
-
     fixture.Customizations.Add(new TypeRelay(typeof(Animal), typeof(Dog)));
 
+    // ACT
     var animal = fixture.Create<Animal>();
 
+    // ASSERT
     Assert.That(animal, Is.InstanceOf<Dog>());
 }
 ```
 
-AutoFixture uses relays to automatically register well-known BCL interfaces to concrete types. The most common use cases are [collection interfaces](Default-configurations#collections).
+AutoFixture uses relays to support well-known interfaces like `IList<T>`. The [collection interfaces](Default-configurations#collections) are forwarded to their most common implementation.

--- a/docs/Relays.md
+++ b/docs/Relays.md
@@ -1,0 +1,27 @@
+AutoFixture is focused on creating instances of concrete types. For this reason it doesn't have any support for non-concrete types like interfaces and abstract classes.
+
+Most of the time, AutoFixture needs to resort to other libraries, like Moq, to create objects implementing an interface or representing a dummy specialization of an abstract class.
+
+Sometimes, it's sufficient to return a concrete type whenever a non-concrete type is requested. To handle cases like this, AutoFixture offers the class `TypeRelay`.
+
+A `TypeRelay` is a customization that can be fed to the Fixture that simply maps relays requests of a certain type to another one.
+
+```csharp
+public abstract class Animal { }
+
+public class Dog : Animal { }
+
+[Test]
+public void Fixture_should_return_relayed_type()
+{
+    var fixture = new Fixture();
+
+    fixture.Customizations.Add(new TypeRelay(typeof(Animal), typeof(Dog)));
+
+    var animal = fixture.Create<Animal>();
+
+    Assert.That(animal, Is.InstanceOf<Dog>());
+}
+```
+
+AutoFixture uses relays to automatically register well-known BCL interfaces to concrete types. The most common use cases are [collection interfaces](Default-configurations#collections).


### PR DESCRIPTION
Adds a page about Relays in AutoFixture. Specifically a sample usage of TypeRelay is provided.