### PR TITLE
Extend Idioms page to include new support for `IEqualityComparer<T>`

### DIFF
--- a/docs/autofixture/idioms.md
+++ b/docs/autofixture/idioms.md
@@ -187,7 +187,7 @@ Specifically, these assertions are available:
 * `EqualsSuccessiveAssertion` verifies that `Object.Equals` is implemented so that calling `x.Equals(y)` several times returns always the same value,
 * `GetHashCodeSuccessiveAssertion` verifies that `Object.GetHashCode` is implemented so that calling `x.GetHashCode()` several times returns always the same value.
 
-As of today, developers are left to write unit tests that prove that the symmetric and transitive properties are respected. [This package](https://www.nuget.org/packages/EqualityTests/) contains the missing tests. Since it's based on AutoFixture 3.36, it might not work with newer versions but developers can take inspiration from [its source code](https://github.com/baks/EqualityTests).
+As of today, developers are left to write unit tests that prove that the symmetric and transitive properties are respected but they can be found in [this package](https://www.nuget.org/packages/EqualityTests/). Since this package is based on AutoFixture 3.36, it might not work with newer versions but developers can take inspiration from [its source code](https://github.com/baks/EqualityTests).
 
 Since most likely all the equality assertions needs to be checked, these can be combined into a single one specializing the `CompositeIdiomaticAssertion` abstract class.
 

--- a/docs/autofixture/idioms.md
+++ b/docs/autofixture/idioms.md
@@ -256,3 +256,47 @@ public void Equality_is_correctly_implemented()
 
 The main advantage of this approach is that developers can later on expand the `EqualityAssertion` class by addition additional child assertions.
 
+### Equality comparers
+
+When it's not possible to customize the behavior of the class, or simply it's preferrable to have multiple equality comparison strategies (like the case of the different string comparers), developers can create their own comparers by implementing the interface `IEqualityComparer<T>`.
+
+This interface exposes two methods, `bool Equals(T,T)` and `int GetHashCode(T)`, and the same rules applying for value equality need to be followed when implementing this interface.
+
+Starting from version 4.14.0, AutoFixture includes a `EqualityComparerAssertion` that can be used to validate the implementation of the custom equality comparer.
+
+Let's consider the following equality comparer for the class `SampleValueObject` displayed above
+```csharp
+public class SampleValueObjectEqualityComparer : IEqualityComparer<SampleValueObject>
+{
+	public bool Equals(SampleValueObject x, SampleValueObject y)
+	{
+		if (x is null && y is null) return true;
+		
+		if (x is null ^ y is null) return false;
+		
+		return string.Equals(x.StringValue, y.StringValue) && Equals(x.IntValue, y.IntValue);
+	}
+
+	public int GetHashCode(SampleValueObject obj)
+	{
+		_ = obj ?? throw new ArgumentNullException(nameof(obj));
+		
+		return HashCode.Combine(typeof(SampleValueObject), obj.StringValue, obj.IntValue);
+	}
+}
+```
+
+By using the `EqualityComparerAssertion`, we can test all the equality properties listed above in a single unit test.
+
+```csharp
+[Test]
+public void Equality_comparer_is_correctly_implemented()
+{
+    //ARRANGE
+    var fixture = new Fixture();
+    var assertion = fixture.Create<EqualityComparerAssertion>();
+
+    // ACT & ASSERT
+    assertion.Verify(typeof(SampleValueObjectEqualityComparer));
+}
+```

--- a/docs/autofixture/idioms.md
+++ b/docs/autofixture/idioms.md
@@ -187,7 +187,7 @@ Specifically, these assertions are available:
 * `EqualsSuccessiveAssertion` verifies that `Object.Equals` is implemented so that calling `x.Equals(y)` several times returns always the same value,
 * `GetHashCodeSuccessiveAssertion` verifies that `Object.GetHashCode` is implemented so that calling `x.GetHashCode()` several times returns always the same value.
 
-As of today, developers are left to write unit tests that prove that the symmetric and transitive properties are respected.
+As of today, developers are left to write unit tests that prove that the symmetric and transitive properties are respected. [This package](https://www.nuget.org/packages/EqualityTests/) contains the missing tests. Since it's based on AutoFixture 3.36, it might not work with newer versions but developers can take inspiration from [its source code](https://github.com/baks/EqualityTests).
 
 Since most likely all the equality assertions needs to be checked, these can be combined into a single one specializing the `CompositeIdiomaticAssertion` abstract class.
 


### PR DESCRIPTION
This PR adds a paragraph to the Idioms page that shows how to use the new `EqualityComparerAssertion` introduced in AutoFixture 4.14.0.

It also adds a link to the package [EqualityTests by baks](https://www.nuget.org/packages/EqualityTests/).

Fixes #35 